### PR TITLE
Use Bundler for dependencies; add Gemfile and update README

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+gem 'rack'
+gem 'thin'
+gem 'kramdown'
+gem 'mustache'
+gem 'viddl-rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,48 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    daemons (1.2.3)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    eventmachine (1.0.8)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    kramdown (1.8.0)
+    mime-types (2.6.2)
+    mini_portile (0.6.2)
+    multi_json (1.10.1)
+    mustache (1.0.2)
+    netrc (0.10.3)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    progressbar (0.21.0)
+    rack (1.6.4)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    thin (1.6.4)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
+    viddl-rb (1.1.1)
+      multi_json (~> 1.10.0)
+      nokogiri (~> 1.6.0)
+      progressbar (~> 0.21)
+      rest-client
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kramdown
+  mustache
+  rack
+  thin
+  viddl-rb
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -12,19 +12,19 @@ Usage
 ### Get Stopwork
 There is no Ruby Gem yet, so the installation procedure is manual.
 
-Install Stopwork's dependancies.
-
-```
-$ gem install kramdown
-$ gem install mustache
-$ gem install viddl-rb
-```
-
 Grab the code off of GitHub and `cd` into the folder.
 
 ```
 $ git clone git@github.com:nasser/stopwork.git
 $ cd stopwork
+```
+
+Install Stopwork's dependencies.
+Dependencies are managed using [Bundler](http://bundler.io/).
+
+```
+$ gem install bundler
+$ bundle install
 ```
 
 ### Write presentation
@@ -51,7 +51,7 @@ Each line represents a slide. Blank lines and lines beggining with `;` are ignor
 Launch the presentation by running the script in the `bin` folder with the path to the presentation file as an argument
 
 ```
-$ ./bin/stopwork presentation.stpwrk
+$ bundle exec ./bin/stopwork presentation.stpwrk
 ```
 
 This will spin up a server at `http://localhost:54021` where your presentation can be found.
@@ -67,7 +67,7 @@ To work in environments without reliable internet, stopwork will cache all image
 To share your presentation, export it
 
 ```
-$ ./bin/stopwork export presentation.stpwrk
+$ bundle exec ./bin/stopwork export presentation.stpwrk
 ```
 
 This will create `presentation.stpwrk.html` with all the CSS and JavaScript embedded in it.


### PR DESCRIPTION
The installation process fails for users who don't have the rack and thin gems installed. This PR should fix that.